### PR TITLE
Update DummyOnStatic.as

### DIFF
--- a/Entities/Structures/Common/DummyOnStatic.as
+++ b/Entities/Structures/Common/DummyOnStatic.as
@@ -20,8 +20,11 @@ void onSetStatic(CBlob@ this, const bool isStatic)
 			}
 			else
 			{
-				map.server_SetTile(POSITION, CMap::tile_empty);
-				server_setDummyGridNetworkID(map.getTileOffset(POSITION), 0);
+				if (this.getHealth()==0) //this check fixes Obstructor and Sensor breaking background
+				{ 
+					map.server_SetTile(POSITION, CMap::tile_empty);
+					server_setDummyGridNetworkID(map.getTileOffset(POSITION), 0);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Status

- **READY**: this PR is (to the best of your knowledge) ready to be incorporated into the game.
- 
## Description

Background and grass will no longer break when selecting obstructor/sensor and then something else in the build menu.

The same code in DummyOnStatic.as is executed when "selecting obstructor/sensor and then something else" and when the tile actually breaks. So I check the tile's health to make sure the code only executes in the latter case, when the health is 0.

I play-tested the change and the two components behave the same as before.