### PR TITLE
FakeRolling improvement

### DIFF
--- a/Entities/Common/Movement/FakeRolling.as
+++ b/Entities/Common/Movement/FakeRolling.as
@@ -1,56 +1,38 @@
+#define CLIENT_ONLY;
+
 const float MAX_ROTATION_SPEED = 60.0f;
 
 void onInit(CBlob@ this)
 {
 	f32 angle = (this.getNetworkID() * 977) % 360;
-	this.set_f32("angle 0", angle);
-	this.set_f32("angle 1", angle);
-	this.set_bool("should rotate 0", true);
-	this.set_bool("should rotate 1", true);
+	this.set_f32("angle", angle);
+	this.set_f32("old_angle", angle);
+
+	this.getCurrentScript().runFlags |= Script::tick_not_attached;
+	this.getCurrentScript().runFlags |= Script::tick_moving;
+	this.getCurrentScript().runFlags |= Script::tick_not_sleeping;
 }
 
 void onTick(CBlob@ this)
-{	
-	if (this.isAttached())	
-	{
-		this.set_f32("angle 0", 0.0f);
-		this.set_f32("angle 1", 0.0f);		
-		return;
-	}
-	
-	f32 old_angle 			= this.get_f32("angle " + getGameTime() % 2); 
-	bool old_should_rotate 	= this.get_bool("should rotate " + getGameTime() % 2);
-	
-	if (isServer())
-	{
-		Vec2f vel 				= this.getVelocity();
-		bool new_should_rotate	= false;
-	
-		if (Maths::Abs(vel.x) > 0)
-		{
-			f32 angle = old_angle + Maths::Clamp(vel.x / this.getRadius() * 180.0f / Maths::Pi, -MAX_ROTATION_SPEED, MAX_ROTATION_SPEED);
-			if (angle > 360.0f)
-				angle -= 360.0f;
-			else if (angle < -360.0f)
-				angle += 360.0f;
-					
-			this.set_f32("angle " + (getGameTime() + 1) % 2, angle);
-			this.Sync("angle " + (getGameTime() + 1) % 2, true);
-			
-			new_should_rotate = true;
-		}
+{
+	f32 angle = this.get_f32("angle");
+	this.set_f32("old_angle", angle);
 
-		this.set_bool("should rotate " + (getGameTime() + 1) % 2, new_should_rotate);
-		this.Sync("should rotate " + (getGameTime() + 1) % 2, true);
-	}
-
-	if (old_should_rotate)
+	Vec2f vel = this.getVelocity();
+	if (Maths::Abs(vel.x) > 0.1)
 	{
-		this.setAngleDegrees(old_angle);
+		angle += Maths::Clamp(vel.x / this.getRadius() * 180.0f / Maths::Pi, -MAX_ROTATION_SPEED, MAX_ROTATION_SPEED);
+		if (angle > 360.0f)
+			angle -= 360.0f;
+		else if (angle < -360.0f)
+			angle += 360.0f;
+		this.set_f32("angle", angle);
+		this.setAngleDegrees(angle);
 	}
 }
 
-void onAttach(CBlob@ this, CBlob@ attached, AttachmentPoint @attachedPoint)
+void onAttach(CBlob@ this, CBlob@ attached, AttachmentPoint@ attachedPoint)
 {
+	this.set_f32("angle", 0.0f);
 	this.setAngleDegrees(0.0f);
 }


### PR DESCRIPTION
1) FakeRolling is something that only needs to be calculated by the *client*. there is no need for a server to be using resources to synchronize the blob's angle when the angle is not used by the server anyways. Not to mention that syncing nearly every tick is a recipe for bad deltas. 
2) You renamed/removed variables that were being used in other scripts (angle & old_angle). If you rename variables, make sure it won't cause problems in other scripts like it would have here.
3) I added a line in onAttach to smoothen visual effect when detaching the blob.